### PR TITLE
Update Power Automate webhook URLs

### DIFF
--- a/test-webhook.js
+++ b/test-webhook.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 
-const WEBHOOK_URL = 'https://prod-71.westus.logic.azure.com:443/workflows/b76a5e4ad5ea49978990e86679806fc4/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=TXM1g4mf6lpViRgQ0JrYAa59-TAvg-UjC24ZZECDFzI';
+const WEBHOOK_URL = 'https://defaultfb12319557d4485c8875f5c0f8136c.67.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/b76a5e4ad5ea49978990e86679806fc4/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=ihlvAFpb9QOX84aQgpqC5a6mBRyFeFYaTizymibcfnU';
 
 async function testWebhook() {
   try {

--- a/utils/webhook.js
+++ b/utils/webhook.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 
 // Webhook URLs for Microsoft Teams
 // Sales notifications
-const SALES_WEBHOOK_URL = process.env.TEAMS_WEBHOOK_URL || 'https://prod-71.westus.logic.azure.com:443/workflows/b76a5e4ad5ea49978990e86679806fc4/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=TXM1g4mf6lpViRgQ0JrYAa59-TAvg-UjC24ZZECDFzI';
+const SALES_WEBHOOK_URL = process.env.TEAMS_WEBHOOK_URL || 'https://defaultfb12319557d4485c8875f5c0f8136c.67.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/b76a5e4ad5ea49978990e86679806fc4/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=ihlvAFpb9QOX84aQgpqC5a6mBRyFeFYaTizymibcfnU';
 // Get Ready notifications
 const GETREADY_WEBHOOK_URL = process.env.TEAMS_GETREADY_WEBHOOK_URL;
 


### PR DESCRIPTION
## Summary
- replace the deprecated Power Automate trigger URL with the new endpoint in the webhook utility and test helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcd1a9c17c8322a6eb65f786b67761