### PR TITLE
Restrict salesperson loaner sheet access

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -32,6 +32,27 @@ function brandOf(stock, model) {
   return (s.startsWith('PM') || m.includes('MINI')) ? 'MINI' : 'BMW';
 }
 
+// Remove operational follow-up tables from a saved sheet for salesperson
+// responses. The fallback handles sheets generated before supplemental
+// sections received explicit markers.
+function primaryTableOnly(html) {
+  const marked = html.replace(
+    /<div data-loaner-supplemental="true">[\s\S]*?<\/div>/g,
+    ''
+  );
+  if (marked !== html) return marked;
+
+  const primaryStart = html.search(/<table\b[^>]*class="sortable"/i);
+  if (primaryStart < 0) return html;
+  const primaryClose = html.indexOf('</table>', primaryStart);
+  const footerStart = html.indexOf('style="padding:18px 24px 26px;"', primaryClose);
+  if (primaryClose < 0 || footerStart < 0) return html;
+  const sectionRowClose = html.lastIndexOf('</td></tr>', footerStart);
+  const primaryEnd = primaryClose + '</table>'.length;
+  if (sectionRowClose <= primaryEnd) return html;
+  return html.slice(0, primaryEnd) + html.slice(sectionRowClose);
+}
+
 const FILTER_BTN =
   'font-family:Arial,Helvetica,sans-serif;font-size:12px;font-weight:bold;' +
   'padding:6px 14px;border:1px solid #1c69d4;background:#ffffff;color:#1c69d4;cursor:pointer;';
@@ -93,6 +114,7 @@ function renderSheet(report, settings, { reportDate = new Date(), includeDisclos
         <td data-v="${(u.tsdMiles || 0) - (u.vautoOdometer || 0)}" ${td('text-align:right;')}>${milesFmt((u.tsdMiles || 0) - (u.vautoOdometer || 0))}</td>
       </tr>`).join('');
     sections.push(`
+    <div data-loaner-supplemental="true">
     <h2 style="font-family:${FONT};font-size:15px;color:${DARK};margin:28px 0 8px;">
       &#9650; Mileage updates needed in vAuto (${updates.length})
     </h2>
@@ -106,7 +128,8 @@ function renderSheet(report, settings, { reportDate = new Date(), includeDisclos
         <th ${THR}>vAuto Odo<span class="arw"></span></th><th ${THR}>Fleet Miles<span class="arw"></span></th><th ${THR}>Difference<span class="arw"></span></th>
       </tr></thead>
       <tbody>${updateRows}</tbody>
-    </table>`);
+    </table>
+    </div>`);
   }
 
   if (attention.length) {
@@ -122,6 +145,7 @@ function renderSheet(report, settings, { reportDate = new Date(), includeDisclos
         <td ${td(`color:${MUTED};font-size:12px;`)}>${esc(u.warnings.join('; '))}</td>
       </tr>`).join('');
     sections.push(`
+    <div data-loaner-supplemental="true">
     <h2 style="font-family:${FONT};font-size:15px;color:${DARK};margin:28px 0 8px;">
       Not priced — needs attention (${attention.length})
     </h2>
@@ -130,7 +154,8 @@ function renderSheet(report, settings, { reportDate = new Date(), includeDisclos
         <th ${TH}>Stock #<span class="arw"></span></th><th ${TH}>Model<span class="arw"></span></th><th ${THR}>Miles<span class="arw"></span></th><th ${TH}>Reason<span class="arw"></span></th><th ${TH}>Detail</th>
       </tr></thead>
       <tbody>${attRows}</tbody>
-    </table>`);
+    </table>
+    </div>`);
   }
 
   if (report.missingFromVauto.length) {
@@ -141,6 +166,7 @@ function renderSheet(report, settings, { reportDate = new Date(), includeDisclos
         <td ${td()}>${esc(m.status)}</td>
       </tr>`).join('');
     sections.push(`
+    <div data-loaner-supplemental="true">
     <h2 style="font-family:${FONT};font-size:15px;color:${DARK};margin:28px 0 8px;">
       In the fleet report but not in vAuto (${report.missingFromVauto.length})
     </h2>
@@ -150,7 +176,8 @@ function renderSheet(report, settings, { reportDate = new Date(), includeDisclos
     <table role="presentation" cellpadding="0" cellspacing="0" class="sortable" style="border-collapse:collapse;font-family:${FONT};font-size:13px;color:${DARK};">
       <thead><tr><th ${TH}>Unit #<span class="arw"></span></th><th ${TH}>Model<span class="arw"></span></th><th ${THR}>Miles<span class="arw"></span></th><th ${TH}>Status<span class="arw"></span></th></tr></thead>
       <tbody>${missingRows}</tbody>
-    </table>`);
+    </table>
+    </div>`);
   }
 
   if (includeDisclosures) {
@@ -158,8 +185,10 @@ function renderSheet(report, settings, { reportDate = new Date(), includeDisclos
       `<p style="font-family:${FONT};font-size:10px;color:${MUTED};margin:0 0 8px;">` +
       `<b>${esc(u.stockNumber)}</b> — ${esc(u.disclosure)}</p>`).join('');
     sections.push(`
+    <div data-loaner-supplemental="true">
     <h2 style="font-family:${FONT};font-size:15px;color:${DARK};margin:28px 0 8px;">Disclosures</h2>
-    ${disc}`);
+    ${disc}
+    </div>`);
   }
 
   const programDate = settings.program_date
@@ -309,4 +338,4 @@ const SORT_SCRIPT = `<script>
 })();
 </script>`;
 
-module.exports = { renderSheet, brandOf };
+module.exports = { renderSheet, brandOf, primaryTableOnly };

--- a/routes/loanerPricing.js
+++ b/routes/loanerPricing.js
@@ -23,9 +23,15 @@ const requireAdmin = (req, res, next) => {
   }
   return res.status(403).json({ message: 'Admin access required' });
 };
+const requireManager = (req, res, next) => {
+  if (req.auth && ['Admin', 'Manager'].includes(req.auth.role)) {
+    return next();
+  }
+  return res.status(403).json({ message: 'Manager access required' });
+};
 const { parseInventory, parseVauto } = require('../lib/parsers');
 const { processFleet } = require('../lib/fleet');
-const { renderSheet } = require('../lib/report');
+const { renderSheet, primaryTableOnly } = require('../lib/report');
 const store = require('../lib/settings');
 const { parseCalculatorWorkbook } = require('../lib/calculatorImport');
 
@@ -44,7 +50,10 @@ router.get('/sheet', authenticate, async (req, res) => {
     const staleRates = Boolean(
       updatedAt && sheet.meta.generatedAt
       && new Date(updatedAt) > new Date(sheet.meta.generatedAt));
-    res.json({ html: sheet.html, meta: sheet.meta, staleRates });
+    const html = req.auth.role === 'Salesperson'
+      ? primaryTableOnly(sheet.html)
+      : sheet.html;
+    res.json({ html, meta: sheet.meta, staleRates });
   } catch (error) {
     console.error('Error loading sheet:', error);
     res.status(500).json({ message: 'Failed to load sheet' });
@@ -54,6 +63,7 @@ router.get('/sheet', authenticate, async (req, res) => {
 router.post(
   '/generate',
   authenticate,
+  requireManager,
   upload.fields([{ name: 'inventory', maxCount: 1 }, { name: 'vauto', maxCount: 1 }]),
   async (req, res) => {
     try {


### PR DESCRIPTION
## What changed
- Return only the primary loaner pricing table to salesperson users.
- Preserve manager/admin access to operational follow-up tables.
- Restrict loaner data generation to managers and admins.
- Support both newly generated and existing saved sheets.

## Why
Salespeople should see customer-facing loaner pricing without operational mileage, exception, or disclosure tables.

## Validation
- `node --test test/engine.test.js` (4 passing; all 95 workbook vectors match)
- Targeted salesperson sheet restriction check